### PR TITLE
fixed party channel bug && optimized lookup for tileCreature in ghostMode

### DIFF
--- a/src/party.cpp
+++ b/src/party.cpp
@@ -113,10 +113,9 @@ bool Party::leaveParty(Player* player)
 		memberList.erase(it);
 	}
 
-	player->setParty(nullptr);
 	player->sendClosePrivate(CHANNEL_PARTY);
+	player->setParty(nullptr);
 	g_game.updatePlayerShield(player);
-
 	for (Player* member : memberList) {
 		member->sendCreatureSkull(player);
 		player->sendPlayerPartyIcons(member);
@@ -125,7 +124,6 @@ bool Party::leaveParty(Player* player)
 	leader->sendCreatureSkull(player);
 	player->sendCreatureSkull(player);
 	player->sendPlayerPartyIcons(leader);
-
 	player->sendTextMessage(MESSAGE_INFO_DESCR, "You have left the party.");
 
 	updateSharedExperience();

--- a/src/tile.cpp
+++ b/src/tile.cpp
@@ -537,15 +537,14 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 		}
 
 		
-		const CreatureVector* creatures = getCreatures();
+		const CreatureVector* tileCreatures = getCreatures();
 		if (const Player* player = creature->getPlayer()) {
-			if (creatures) {
-				for (const Creature* tileCreature : *creatures) {
-					if (!hasBitSet(FLAG_IGNOREBLOCKCREATURE, flags) 
-					    && !player->isAccessPlayer() 
-					    && !tileCreature->isInGhostMode()) {
+			if (tileCreatures && !tileCreatures->empty()
+			    && !hasBitSet(FLAG_IGNOREBLOCKCREATURE, flags)
+			    && !player->isAccessPlayer()) {
+				for (const Creature* tileCreature : *tileCreatures) {
+					if (!tileCreature->isInGhostMode())
 						return RETURNVALUE_NOTPOSSIBLE;
-					}
 				}
 			}
 
@@ -572,8 +571,8 @@ ReturnValue Tile::queryAdd(int32_t, const Thing& thing, uint32_t, uint32_t flags
 					return RETURNVALUE_PLAYERISPZLOCKED;
 				}
 			}
-		} else if (creatures && !creatures->empty() && !hasBitSet(FLAG_IGNOREBLOCKCREATURE, flags)) {
-			for (const Creature* tileCreature : *creatures) {
+		} else if (tileCreatures && !tileCreatures->empty() && !hasBitSet(FLAG_IGNOREBLOCKCREATURE, flags)) {
+			for (const Creature* tileCreature : *tileCreatures) {
 				if (!tileCreature->isInGhostMode()) {
 					return RETURNVALUE_NOTENOUGHROOM;
 				}


### PR DESCRIPTION
to use Player::sendClosePrivate correctly it needs the player's party information to remove the player from the channel , the code was setting the player's party to null too early. 
I can think of a better fix to this problem, moving the leaveParty method to the player class and use removeMember from the Party class. then these kind of bugs wouldn't happen so easy.